### PR TITLE
Feat: "사진, 파일, 음성등 보내기 그리드 뷰 수정"

### DIFF
--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatActivity.java
@@ -179,9 +179,6 @@ public class ChatActivity extends AppCompatActivity implements ChatSendOthersAct
 
                 if(message!=null){
                     webSocket.send(message);
-
-                    ChatBubble chatBubble = new ChatBubble(chatDto);
-                    chatHistoryAdapter.addChatMsg(chatBubble);
                     recyclerView.scrollToPosition(chatHistoryAdapter.getItemCount() - 1);
 
                     inputMsgTextView.setText(null);
@@ -333,9 +330,6 @@ public class ChatActivity extends AppCompatActivity implements ChatSendOthersAct
 
         if(message!=null){
             webSocket.send(message);
-
-            ChatBubble chatBubble = new ChatBubble(chatDto);
-            chatHistoryAdapter.addChatMsg(chatBubble);
             recyclerView.scrollToPosition(chatHistoryAdapter.getItemCount() - 1);
         } else {
             Toast.makeText(getApplicationContext(), "메세지 전송에 실패하였습니다.", Toast.LENGTH_SHORT).show();

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatSendOthersActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatSendOthersActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -28,6 +29,9 @@ import com.example.modumessenger.Retrofit.RetrofitClient;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -44,6 +48,8 @@ public class ChatSendOthersActivity extends BottomSheetDialogFragment {
     GridView settingGridView;
     SendOthersGridAdapter sendOthersGridAdapter;
     String roomId;
+
+    List<SendOthers> sendOthersList;
 
     private ChatSendOthersBottomSheetListener mListener;
 
@@ -83,12 +89,13 @@ public class ChatSendOthersActivity extends BottomSheetDialogFragment {
 
     private void setData() {
         scopedStorageUtil = new ScopedStorageUtil();
+        sendOthersList = new ArrayList<>(Arrays.asList(SendOthers.SEND_OTHERS_GALLERY, SendOthers.SEND_OTHERS_CAMERA, SendOthers.SEND_OTHERS_FILE, SendOthers.SEND_OTHERS_AUDIO));
     }
 
     private void bindingView(View view) {
         settingGridView = view.findViewById(R.id.send_others_grid);
         sendOthersGridAdapter = new SendOthersGridAdapter(requireActivity());
-        sendOthersGridAdapter.setGridItems(view);
+        sendOthersGridAdapter.setGridItems(view, sendOthersList);
 
         settingGridView.setAdapter(sendOthersGridAdapter);
     }
@@ -98,17 +105,11 @@ public class ChatSendOthersActivity extends BottomSheetDialogFragment {
             SendOthersGridItem gridItem = sendOthersGridAdapter.getGridItem(position);
             Toast.makeText(requireActivity().getApplicationContext(), gridItem.getItemName(), Toast.LENGTH_SHORT).show();
 
-            if(position==0) {
-                Intent intent = new Intent();
-                intent.setType("image/*");
-                intent.setAction(Intent.ACTION_GET_CONTENT);
-                resultLauncher.launch(intent);
-            } else if(position == 2) {
-                Intent intent = new Intent();
-                intent.setType("image/*");
-                intent.setAction(Intent.ACTION_GET_CONTENT);
-                resultLauncher.launch(intent);
-            }
+            SendOthers sendOthers = this.sendOthersList.get(position);
+            Intent intent = new Intent();
+            intent.setAction(sendOthers.getSendItemAction());
+            intent.setType(sendOthers.getSendItemExtension() == null ? "*/*" : sendOthers.getSendItemExtension());
+            resultLauncher.launch(intent);
         });
     }
 
@@ -146,6 +147,30 @@ public class ChatSendOthersActivity extends BottomSheetDialogFragment {
         cursor.close();
 
         return fileName;
+    }
+
+    public enum SendOthers {
+        SEND_OTHERS_GALLERY("앨범", "image/*", Intent.ACTION_GET_CONTENT, R.drawable.ic_baseline_image_24),
+        SEND_OTHERS_CAMERA("카메라", null, MediaStore.ACTION_IMAGE_CAPTURE, R.drawable.ic_baseline_photo_camera_24),
+        SEND_OTHERS_FILE("파일", "*/*", Intent.ACTION_GET_CONTENT, R.drawable.ic_baseline_attach_file_24),
+        SEND_OTHERS_AUDIO("음성", "audio/*", Intent.ACTION_GET_CONTENT, R.drawable.ic_baseline_audio_file_24);
+
+        private final String sendItemName;
+        private final String sendItemExtension;
+        private final String sendItemAction;
+        private final int sendItemImage;
+
+        SendOthers(String sendItemName, String sendItemExtension, String sendItemAction, int sendItemImage) {
+            this.sendItemName = sendItemName;
+            this.sendItemExtension = sendItemExtension;
+            this.sendItemAction = sendItemAction;
+            this.sendItemImage = sendItemImage;
+        }
+
+        public String getSendItemName() { return sendItemName; }
+        public String getSendItemExtension() { return sendItemExtension; }
+        public String getSendItemAction() { return sendItemAction; }
+        public int getSendItemImage() { return sendItemImage; }
     }
 
     // Retrofit function

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatRoomAdapter.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatRoomAdapter.java
@@ -169,7 +169,7 @@ public class ChatRoomAdapter extends RecyclerView.Adapter<ChatRoomAdapter.ChatRo
         }
 
         public void setChatRoomLastTime(ChatRoom chatRoom) {
-            this.lastChatTime.setText(!chatRoom.getLastChatTime().equals("") ? getShortTime(chatRoom.getLastChatTime()) : "");
+            this.lastChatTime.setText(chatRoom.getLastChatTime().equals("") || chatRoom.getLastChatMsg().equals("") ? "" : getShortTime(chatRoom.getLastChatTime()));
         }
 
         public void setChatRoomImage(ChatRoom chatRoom) {

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Grid/SendOthersGridAdapter.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Grid/SendOthersGridAdapter.java
@@ -10,6 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.example.modumessenger.Activity.ChatSendOthersActivity;
 import com.example.modumessenger.R;
 
 import java.util.ArrayList;
@@ -61,10 +62,8 @@ public class SendOthersGridAdapter extends BaseAdapter {
         return convertView;
     }
 
-    public void setGridItems(View view) {
-        setGridItem(new SendOthersGridItem("사진 전송", R.drawable.ic_baseline_image_24));
-        setGridItem(new SendOthersGridItem("파일 전송", R.drawable.ic_baseline_attach_file_24));
-        setGridItem(new SendOthersGridItem("음성 전송", R.drawable.ic_baseline_audio_file_24));
+    public void setGridItems(View view, List<ChatSendOthersActivity.SendOthers> sendOthersList) {
+        sendOthersList.forEach(sendOthers -> setGridItem(new SendOthersGridItem(sendOthers.getSendItemName(), sendOthers.getSendItemImage())));
     }
 
     public void setGridItem(SendOthersGridItem sendOthersGridItem) {

--- a/android/ModuMessenger/app/src/main/res/drawable/ic_baseline_photo_camera_24.xml
+++ b/android/ModuMessenger/app/src/main/res/drawable/ic_baseline_photo_camera_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#ABABAB"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>


### PR DESCRIPTION
Feat: "사진, 파일, 음성등 보내기 그리드 뷰 수정"

사진, 파일, 음성등 보내기 그리드 뷰 로직 관련 수정
- 사진찍고 보내기 뷰 추가
채팅 수신후 뷰 갱신 로직 수정 (채팅 두번 표시되는 문제 수정)
채팅 목록에서 수신된 메시지 없는 경우 맨 아래로 정렬되는 문제 수정
- 수신된 메시지가 없더라도 최근에 생성된 채팅방이면 상단에 표시

Resolves: N/A
Ref: N/A
Related to: N/A