### PR TITLE
Feat: "채팅 메시지로 채팅 내역 조회 api 추가"

### DIFF
--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/controller/ChatController.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/controller/ChatController.java
@@ -29,4 +29,10 @@ public class ChatController {
         ChatDto chatDto = chatService.searchChatByRoomIdAndChatId(roomId, chatId);
         return ResponseEntity.ok().body(chatDto);
     }
+
+    @GetMapping("/chat/{roomId}/chat")
+    public ResponseEntity<List<ChatDto>> getChatByMessage(@Valid @PathVariable("roomId") String roomId, @Valid @RequestParam String message) {
+        List<ChatDto> chatDtoList = chatService.searchChatByMessage(roomId, message);
+        return ResponseEntity.ok().body(chatDtoList);
+    }
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatCustomRepository.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatCustomRepository.java
@@ -1,6 +1,7 @@
 package com.example.modumessenger.chat.repository;
 
 import com.example.modumessenger.chat.entity.Chat;
+import org.modelmapper.ModelMapper;
 
 import java.util.List;
 
@@ -9,6 +10,8 @@ public interface ChatCustomRepository {
     List<Chat> findAllQueryDsl();
 
     Chat findByRoomIdAndChatId(String roomId, Long chatId);
+
+    List<Chat> findByMessage(String roomId, String message);
 
     Long countAll();
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatRepositoryImpl.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.modumessenger.chat.repository;
 import com.example.modumessenger.chat.entity.Chat;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 
 import java.util.List;
 
@@ -31,6 +32,13 @@ public class ChatRepositoryImpl implements ChatCustomRepository {
                 .fetchOne();
     }
 
+    @Override
+    public List<Chat> findByMessage(String roomId, String message) {
+        return queryFactory
+                .selectFrom(chat)
+                .where(chat.roomId.eq(roomId).and(chat.message.contains(message)))
+                .fetch();
+    }
 
     @Override
     public Long countAll() {

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatRoomService.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatRoomService.java
@@ -12,6 +12,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -60,7 +62,8 @@ public class ChatRoomService {
     public ChatRoomDto createChatRoom(List<String> userId) {
         List<Member> members = memberRepository.findAllByUserIds(userId);
 
-        ChatRoom chatRoom = new ChatRoom(UUID.randomUUID().toString(), "새로운 채팅방", "", "", "");
+        String chatRoomCreateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        ChatRoom chatRoom = new ChatRoom(UUID.randomUUID().toString(), "새로운 채팅방", "", "", chatRoomCreateTime);
 
         List<ChatRoomMember> chatRoomMemberList = members.stream()
                         .map(member -> {

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatService.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatService.java
@@ -30,6 +30,14 @@ public class ChatService {
                 .collect(Collectors.toList());
     }
 
+    public List<ChatDto> searchChatByMessage(String roomId, String message) {
+        List<Chat> chatList = chatRepository.findByMessage(roomId, message);
+        return chatList
+                .stream()
+                .map(c -> modelMapper.map(c, ChatDto.class))
+                .collect(Collectors.toList());
+    }
+
     public ChatDto searchChatById(String chatId) {
         Long id = Long.parseLong(chatId);
         Optional<Chat> chat = chatRepository.findById(id);

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/common/handler/WebSocketHandler.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/common/handler/WebSocketHandler.java
@@ -88,20 +88,6 @@ public class WebSocketHandler extends TextWebSocketHandler implements MessageLis
 
         ChannelTopic channel = new ChannelTopic(CHAT_MESSAGING_TOPIC_NAME);
         messagingPublisher.publish(channel, chatMessage);
-
-//        chatRoomDto.getMembers().forEach(member -> {
-//            String userId = member.getUserId();
-//            if(!sender.getUserId().equals(userId)) {
-//                WebSocketSession s = CLIENTS.get(userId);
-//                if (s != null) {
-//                    try {
-//                        s.sendMessage(message);
-//                    } catch (IOException e) {
-//                        e.printStackTrace();
-//                    }
-//                }
-//            }
-//        });
     }
 
     @Override


### PR DESCRIPTION
Feat: "채팅 메시지로 채팅 내역 조회 api 추가"

채팅 내용 검색시 포함된 채팅 내역 조회 api 추가
채팅방 생성후 전송된 메시지 없는 경우 맨 아래로 정렬되는 문제 수정
- 수신된 메시지가 없더라도 정렬이 가능하도록 채팅방 생성 시간을 추가

Resolves: #124
Ref: #124
Related to: #124