### PR TITLE
Mod: "채팅 히스토리 조회 수정"

### DIFF
--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatBubble.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatBubble.java
@@ -4,6 +4,7 @@ import com.example.modumessenger.dto.ChatDto;
 
 // Sample Chat
 public class ChatBubble {
+    private Long id;
     private String roomId;
     private String chatMsg;
     private String chatTime;
@@ -19,6 +20,7 @@ public class ChatBubble {
     }
 
     public ChatBubble(ChatDto chatDto) {
+        id = chatDto.getId();
         roomId = chatDto.getRoomId();
         chatMsg = chatDto.getMessage();
         chatType = chatDto.getChatType();
@@ -26,12 +28,14 @@ public class ChatBubble {
         sender = chatDto.getSender();
     }
 
+    public Long getId() { return this.id; }
     public String getRoomId() { return this.roomId; }
     public String getChatMsg() { return this.chatMsg; }
     public String getChatTime() { return this.chatTime; }
     public String getSender() { return this.sender; }
     public int getChatType() { return this.chatType; }
 
+    public void setId(Long id) { this.id = id; }
     public void setRoomId(String roomId) { this.roomId = roomId; }
     public void setChatMsg(String msg) { this.chatMsg = msg; }
     public void setChatTime(String time) { this.chatTime = time; }

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatHistoryAdapter.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatHistoryAdapter.java
@@ -48,7 +48,7 @@ public class ChatHistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
     public ChatHistoryAdapter(List<ChatBubble> chatList, List<Member> memberList) {
         this.memberList = (memberList == null || memberList.size() == 0) ? new ArrayList<>() : memberList;
-        this.chatList = (chatList == null || chatList.size() == 0) ? new ArrayList<>() : chatList;
+        this.chatList = chatList;
         userId = PreferenceManager.getString("userId");
         sortChatBubble();
     }
@@ -209,6 +209,21 @@ public class ChatHistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     @SuppressLint("NotifyDataSetChanged")
     public void addChatMsg(ChatBubble chatBubble) {
         this.chatList.add(chatBubble);
+        notifyDataSetChanged();
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void addChatMsgBack(List<ChatBubble> chatList) {
+        this.chatList.addAll(chatList);
+        notifyDataSetChanged();
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void addChatMsgFront(List<ChatBubble> chatList) {
+        chatList.forEach(chatBubble -> {
+            this.chatList.add(0, chatBubble);
+        });
+
         notifyDataSetChanged();
     }
 

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Retrofit/RetrofitChatAPI.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Retrofit/RetrofitChatAPI.java
@@ -5,6 +5,7 @@ import com.example.modumessenger.dto.ChatDto;
 import java.util.List;
 
 import retrofit2.Call;
+import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
 
@@ -12,4 +13,7 @@ public interface RetrofitChatAPI {
 
     @GET("chat/{roomId}/chats")
     Call<List<ChatDto>> RequestChatHistory(@Path("roomId") String roomId);
+
+    @GET("chat/{roomId}/{chatId}/{size}")
+    Call<List<ChatDto>> RequestPrevChatList(@Path("roomId") String roomId, @Path("chatId") String chatId, @Path("size") String size);
 }

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/dto/ChatDto.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/dto/ChatDto.java
@@ -1,18 +1,21 @@
 package com.example.modumessenger.dto;
 
 public class ChatDto {
+    private  Long id;
     private int chatType;
     private String roomId;
     private String sender;
     private String message;
     private String chatTime;
 
+    public Long getId() { return this.id; }
     public String getRoomId() { return this.roomId; }
     public String getSender() { return this.sender; }
     public String getMessage() { return this.message; }
     public String getChatTime() { return this.chatTime; }
     public int getChatType() { return this.chatType; }
 
+    public void setId(Long id) { this.id = id; }
     public void setRoomId(String roomId) { this.roomId = roomId; }
     public void setSender(String sender) { this.sender = sender; }
     public void setMessage(String message) { this.message = message; }

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/dto/ChatRoomDto.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/dto/ChatRoomDto.java
@@ -10,6 +10,7 @@ public class ChatRoomDto {
     private String roomName;
     private String roomImage;
     private String lastChatMsg;
+    private String lastChatId;
     private String lastChatTime;
     private List<MemberDto> members;
 
@@ -17,6 +18,7 @@ public class ChatRoomDto {
     public String getRoomName() { return this.roomName; }
     public String getRoomImage() { return this.roomImage; }
     public String getLastChatMsg() { return this.lastChatMsg; }
+    public String getLastChatId() { return this.lastChatId; }
     public String getLastChatTime() { return this.lastChatTime; }
     public List<MemberDto> getMembers() { return this.members; }
 
@@ -24,6 +26,7 @@ public class ChatRoomDto {
     public void setRoomName(String roomName) { this.roomName = roomName; }
     public void setRoomImage(String roomImage) { this.roomImage = roomImage; }
     public void setLastChatMsg(String lastChatMsg) { this.lastChatMsg = lastChatMsg; }
+    public void setLastChatId(String lastCHatId) { this.lastChatId = lastCHatId; }
     public void setLastChatTime(String lastChatTime) { this.lastChatTime = lastChatTime; }
     public void setMembers(List<MemberDto> members) { this.members = members; }
 
@@ -32,6 +35,7 @@ public class ChatRoomDto {
         setRoomName(chatRoom.getRoomName());
         setRoomImage(chatRoom.getRoomImage());
         setLastChatMsg(chatRoom.getLastChatMsg());
+        setLastChatId(chatRoom.getLastChatId());
         setLastChatTime(chatRoom.getLastChatTime());
     }
 }

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/entity/ChatRoom.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/entity/ChatRoom.java
@@ -17,6 +17,8 @@ public class ChatRoom {
     private String roomImage;
     @SerializedName("lastChatMsg")
     private String lastChatMsg;
+    @SerializedName("lastChatId")
+    private String lastChatId;
     @SerializedName("lastChatTime")
     private String lastChatTime;
     @SerializedName("chatMember")
@@ -26,6 +28,7 @@ public class ChatRoom {
     public String getRoomName() { return this.roomName; }
     public String getRoomImage() { return this.roomImage; }
     public String getLastChatMsg() { return this.lastChatMsg; }
+    public String getLastChatId() { return this.lastChatId; }
     public String getLastChatTime() { return this.lastChatTime; }
     public List<Member> getMembers() { return this.members; }
 
@@ -33,6 +36,7 @@ public class ChatRoom {
     public void setRoomName(String roomName) { this.roomName = roomName; }
     public void setRoomImage(String roomImage) { this.roomImage = roomImage; }
     public void setLastChatMsg(String lastChatMsg) { this.lastChatMsg = lastChatMsg; }
+    public void setLastChatId(String lastChatId) { this.lastChatId = lastChatId; }
     public void setLastChatTime(String lastChatTime) { this.lastChatTime = lastChatTime; }
     public void setMembers(List<Member> members) { this.members = members; }
 
@@ -41,6 +45,7 @@ public class ChatRoom {
         setRoomName(chatRoomDto.getRoomName());
         setRoomImage(chatRoomDto.getRoomImage());
         setLastChatMsg(chatRoomDto.getLastChatMsg());
+        setLastChatId(chatRoomDto.getLastChatId());
         setLastChatTime(chatRoomDto.getLastChatTime());
         chatRoomDto.getMembers().forEach(member -> {
             members.add(new Member(member));


### PR DESCRIPTION
Mod: "채팅 히스토리 조회 수정"

채팅방 채팅 조회 수정
- 페이징 처리 및 이전 채팅 가져오기 로직 추가
- 이전 채팅 가져온 후 스크롤 제자리로 위치
채팅방 생성후 바로 채팅 보낸후 표시안되는 문제 수정
- 채팅 리스트 어뎁터에 정상적으로 넘겨주도록 수정

Resolves: #128, #129, #132
Ref: #128, #129, #132
Related to: #128, #129, #132