### PR TITLE
Feat: "채팅 히스토리 api 추가"

### DIFF
--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/controller/ChatController.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/controller/ChatController.java
@@ -32,10 +32,14 @@ public class ChatController {
         return ResponseEntity.ok().body(chatDtoList);
     }
 
+    @GetMapping("/chat/{roomId}/page/{size}")
+    public ResponseEntity<List<ChatDto>> getChatListSize(@Valid @PathVariable("roomId") String roomId, @Valid @PathVariable("size") String size) {
+        List<ChatDto> chatDtoList = chatService.searchChatByRoomIdSize(roomId, size);
+        return ResponseEntity.ok().body(chatDtoList);
+    }
+
     @GetMapping("/chat/{roomId}/{chatId}/{size}")
-    public ResponseEntity<List<ChatDto>> getPrevChatList(@Valid @PathVariable("roomId") String roomId,
-                                                         @Valid @PathVariable("chatId") String chatId,
-                                                         @Valid @PathVariable("size") String size) {
+    public ResponseEntity<List<ChatDto>> getPrevChatList(@Valid @PathVariable("roomId") String roomId, @Valid @PathVariable("chatId") String chatId, @Valid @PathVariable("size") String size) {
         List<ChatDto> chatDtoList = chatService.searchPrevChatByRoomId(roomId, chatId, size);
         return ResponseEntity.ok().body(chatDtoList);
     }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatCustomRepository.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatCustomRepository.java
@@ -16,5 +16,7 @@ public interface ChatCustomRepository {
 
     List<Chat> findByRoomIdPaging(String roomId, Pageable pageable);
 
+    List<Chat> findByRoomIdSize(String roomId, Long size);
+
     List<Chat> findByRoomIdAndChatId(String roomId, Long chatId, Long size);
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatRepositoryImpl.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/repository/ChatRepositoryImpl.java
@@ -52,6 +52,17 @@ public class ChatRepositoryImpl implements ChatCustomRepository {
     }
 
     @Override
+    public List<Chat> findByRoomIdSize(String roomId, Long size) {
+        return queryFactory
+                .selectFrom(chat)
+                .where(chat.roomId.eq(roomId))
+                .limit(size)
+                .orderBy(chat.chatTime.desc())
+                .orderBy(chat.id.asc())
+                .fetch();
+    }
+
+    @Override
     public List<Chat> findByRoomIdAndChatId(String roomId, Long chatId, Long size) {
         return queryFactory
                 .selectFrom(chat)

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatService.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/chat/service/ChatService.java
@@ -31,6 +31,14 @@ public class ChatService {
                 .collect(Collectors.toList());
     }
 
+    public List<ChatDto> searchChatByRoomIdSize(String roomId, String size) {
+        List<Chat> chatList = chatRepository.findByRoomIdSize(roomId, Long.parseLong(size));
+        return chatList
+                .stream()
+                .map(c -> modelMapper.map(c, ChatDto.class))
+                .collect(Collectors.toList());
+    }
+
     public List<ChatDto> searchPrevChatByRoomId(String roomId, String chatId, String size) {
         List<Chat> chatList = chatRepository.findByRoomIdAndChatId(roomId, Long.parseLong(chatId), Long.parseLong(size));
         return chatList


### PR DESCRIPTION
Feat: "채팅 히스토리 api 추가"

채팅 내역 조회 api 추가
- 채팅방에 채팅이 없는 경우
- 마지막 채팅 id 없이 조회 해야하는 경우
- 페이징 사이즈만 가지고 조회가 가능한 api

Resolves: #128, #129, #132, #133, #134
Ref: #128, #129, #132, #133, #134
Related to: #128, #129, #132, #133, #134