### PR TITLE
Feat: "푸쉬 알림(fcm) 전송 api 추가"

### DIFF
--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/controller/FcmController.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/controller/FcmController.java
@@ -1,14 +1,30 @@
 package com.example.modumessenger.fcm.controller;
 
+import com.example.modumessenger.fcm.dto.RequestChatDto;
+import com.example.modumessenger.fcm.dto.RequestPushMessage;
 import com.example.modumessenger.fcm.entity.FcmToken;
 import com.example.modumessenger.fcm.service.FcmService;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 public class FcmController {
+
+    @Value("${project.properties.firebase-multicast-message-size}")
+    Long multicastMessageSize;
 
     private final FcmService fcmService;
 
@@ -18,5 +34,43 @@ public class FcmController {
         FcmToken saveToken = fcmService.saveFcmToken(fcmToken);
 
         return ResponseEntity.ok().body(saveToken.getFcmToken());
+    }
+
+    @PostMapping(value = "/push/topics/{topic}")
+    public void notificationTopics(@PathVariable("topic") String topic, @RequestBody RequestPushMessage data) throws FirebaseMessagingException {
+        fcmService.sendTopicMessage(topic, data.getTitle(), data.getBody(), data.getImage());
+    }
+
+    @PostMapping(value = "/push/users")
+    public void notificationUsers(@RequestBody RequestPushMessage data) throws FirebaseMessagingException {
+        List<FcmToken> fcmTokens = fcmService.searchAllFcmToken();
+
+        AtomicInteger counter = new AtomicInteger();
+        Collection<List<FcmToken>> sendUserGroups = fcmTokens.stream().collect(Collectors.groupingBy(it -> counter.getAndIncrement() / multicastMessageSize)).values();
+
+        for (List<FcmToken> it : sendUserGroups) {
+            Notification notification = Notification.builder().setTitle(data.getTitle()).setBody(data.getBody()).setImage(data.getImage()).build();
+            MulticastMessage.Builder builder = MulticastMessage.builder();
+            Optional.ofNullable(data.getData()).ifPresent(builder::putAllData);
+            MulticastMessage message = builder
+                    .setNotification(notification)
+                    .addAllTokens(it.stream().map(FcmToken::getFcmToken).collect(Collectors.toList()))
+                    .build();
+            fcmService.sendMessage(message);
+        }
+    }
+
+    @PostMapping(value = "/push/user/{userId}")
+    public void notificationUser(@PathVariable("userId") String userId, @RequestBody RequestPushMessage data) throws FirebaseMessagingException {
+        FcmToken fcmToken = fcmService.searchFcmToken(userId);
+        fcmService.sendTargetMessage(fcmToken.getFcmToken(), data.getTitle(), data.getBody(), data.getImage());
+    }
+
+    @PostMapping(value = "/push/users/{token}")
+    public void notificationToken(@PathVariable("token") String token, @RequestBody RequestChatDto chatDto) throws FirebaseMessagingException {
+        Notification notification = Notification.builder().setTitle(chatDto.getChatRoomName()).setBody(chatDto.getMessage()).setImage(chatDto.getImage()).build();
+        Message.Builder builder = Message.builder();
+        Message msg = builder.setToken(token).setNotification(notification).build();
+        fcmService.sendMessage(msg);
     }
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/dto/RequestChatDto.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/dto/RequestChatDto.java
@@ -1,0 +1,14 @@
+package com.example.modumessenger.fcm.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RequestChatDto {
+    private String chatRoomName;
+    private String message;
+    private String Image;
+}

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/dto/RequestPushMessage.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/dto/RequestPushMessage.java
@@ -1,0 +1,26 @@
+package com.example.modumessenger.fcm.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RequestPushMessage {
+    String title;
+    String body;
+    Map<String, String> data;
+    String image;
+
+    @Builder
+    public RequestPushMessage(String title, String body, Map<String, String> data, String image) {
+        this.title = title;
+        this.body = body;
+        this.data = data;
+        this.image = image;
+    }
+}

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/repository/FcmRepository.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/repository/FcmRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FcmRepository extends JpaRepository<FcmToken, Long> {
+
+    FcmToken findByUserId(String userId);
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/service/FcmService.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/fcm/service/FcmService.java
@@ -2,9 +2,12 @@ package com.example.modumessenger.fcm.service;
 
 import com.example.modumessenger.fcm.entity.FcmToken;
 import com.example.modumessenger.fcm.repository.FcmRepository;
+import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -15,5 +18,41 @@ public class FcmService {
 
     public FcmToken saveFcmToken(FcmToken fcmToken) {
         return fcmRepository.save(fcmToken);
+    }
+
+    public FcmToken searchFcmToken(String userId) {
+        return fcmRepository.findByUserId(userId);
+    }
+
+    public List<FcmToken> searchAllFcmToken() {
+        return fcmRepository.findAll();
+    }
+
+    public void sendTargetMessage(String targetToken, String title, String body) throws FirebaseMessagingException {
+        this.sendTargetMessage(targetToken, title, body, null);
+    }
+
+    public void sendTargetMessage(String targetToken, String title, String body, String image) throws FirebaseMessagingException {
+        Notification notification = Notification.builder().setTitle(title).setBody(body).setImage(image).build();
+        Message msg = Message.builder().setToken(targetToken).setNotification(notification).build();
+        sendMessage(msg);
+    }
+
+    public void sendTopicMessage(String topic, String title, String body) throws FirebaseMessagingException {
+        this.sendTopicMessage(topic, title, body, null);
+    }
+
+    public void sendTopicMessage(String topic, String title, String body, String image) throws FirebaseMessagingException {
+        Notification notification = Notification.builder().setTitle(title).setBody(body).setImage(image).build();
+        Message msg = Message.builder().setTopic(topic).setNotification(notification).build();
+        sendMessage(msg);
+    }
+
+    public void sendMessage(Message message) throws FirebaseMessagingException {
+        FirebaseMessaging.getInstance().send(message);
+    }
+
+    public void sendMessage(MulticastMessage message) throws FirebaseMessagingException {
+        FirebaseMessaging.getInstance().sendMulticast(message);
     }
 }

--- a/backend/ModuMessenger/src/main/resources/application.yml
+++ b/backend/ModuMessenger/src/main/resources/application.yml
@@ -39,6 +39,5 @@ security:
 
 project:
   properties:
-    firebas-sdk-path: "firebase/modu_chat_firebase_service_key.json"
-    firebase-create-scoped: "https://www.googleapis.com/auth/firebase.messaging"
-    firebase-topic: "modu_chat_notification"
+    firebase-sdk-path: "firebase/modu_chat_firebase_service_key.json"
+    firebase-multicast-message-size: 500


### PR DESCRIPTION
Feat: "푸쉬 알림(fcm) 전송 api 추가"

푸쉬 알림(fcm) 전송 api 추가
- token 으로 특정 사용자의 기기에만 보내기
- 전체 유저에게 보내기
- topic으로 보내기 (topic 구독중인 유저 모두에게 전송)

Resolves: #140, #141, #142, #143
Ref: #140, #141, #142, #143
Related to: #140, #141, #142, #143