### PR TITLE
Feat: "구글 OAuth 로그인시 id_token 검증 로직 추가"

### DIFF
--- a/backend/ModuMessenger/.gitignore
+++ b/backend/ModuMessenger/.gitignore
@@ -36,4 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
+application-oauth.yml
 modu_chat_firebase_service_key.json

--- a/backend/ModuMessenger/build.gradle
+++ b/backend/ModuMessenger/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'com.querydsl:querydsl-jpa'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+    implementation 'com.google.api-client:google-api-client:1.31.2'
+
     implementation 'com.google.firebase:firebase-admin:9.0.0'
 
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
@@ -42,6 +44,8 @@ dependencies {
 
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
+    compile 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    compile 'com.google.api-client:google-api-client:1.31.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     runtimeOnly 'com.h2database:h2'

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/common/Properties/GoogleOauthProperties.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/common/Properties/GoogleOauthProperties.java
@@ -1,2 +1,16 @@
-package com.example.modumessenger.common.Properties;public class GoogleOauthProperties {
+package com.example.modumessenger.common.Properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration.google")
+public class GoogleOauthProperties {
+
+    private String clientId;
+    private String clientSecret;
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/controller/MemberController.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.example.modumessenger.member.controller;
 
+import com.example.modumessenger.member.dto.GoogleLoginRequest;
 import com.example.modumessenger.member.dto.MemberDto;
 import com.example.modumessenger.member.dto.RequestMemberDto;
 import com.example.modumessenger.member.dto.ResponseMemberDto;
@@ -27,8 +28,8 @@ public class MemberController {
     }
 
     @PostMapping("/member/signup")
-    public ResponseEntity<ResponseMemberDto> signupMember(@Valid @RequestBody RequestMemberDto requestMemberDto) {
-        MemberDto memberDto = memberService.registerMember(modelMapper.map(requestMemberDto, MemberDto.class));
+    public ResponseEntity<ResponseMemberDto> signupMember(@Valid @RequestBody GoogleLoginRequest googleLoginRequest) {
+        MemberDto memberDto = memberService.registerMember(googleLoginRequest);
         return ResponseEntity.ok().body(modelMapper.map(memberDto, ResponseMemberDto.class));
     }
 

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/dto/GoogleLoginRequest.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/dto/GoogleLoginRequest.java
@@ -1,2 +1,14 @@
-package com.example.modumessenger.member.dto;public class GoogleLoginRequest {
+package com.example.modumessenger.member.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GoogleLoginRequest {
+
+    private String authType;
+    private String idToken;
 }

--- a/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/dto/MemberDto.java
+++ b/backend/ModuMessenger/src/main/java/com/example/modumessenger/member/dto/MemberDto.java
@@ -6,8 +6,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,5 +37,15 @@ public class MemberDto implements Serializable {
         setProfileImage(member.getProfileImage());
         setWallpaperImage(member.getWallpaperImage());
         setProfileDtoList(member.getProfileList().stream().map(ProfileDto::new).collect(Collectors.toList()));
+    }
+
+    public MemberDto(Payload payload) {
+        setUserId(payload.getSubject());
+        setEmail(payload.getEmail());
+        setAuth("google");
+        setUsername((String) payload.get("name"));
+        setStatusMessage("");
+        setProfileImage((String) payload.get("picture"));
+        setWallpaperImage("");
     }
 }

--- a/backend/ModuMessenger/src/main/resources/application.yml
+++ b/backend/ModuMessenger/src/main/resources/application.yml
@@ -4,6 +4,7 @@ server:
 spring:
   profiles:
     default: local
+    include: oauth
 
   config:
     use-legacy-processing: true


### PR DESCRIPTION
Feat: "구글 OAuth 로그인시 id_token 검증 로직 추가"

구글 OAuth 로그인시 id_token 검증 로직 추가
- singup api 수정
- 안드로이드에서 전달한 id_token을 GoogleIdTokenVerifier 으로 검증
- 토큰이 변조되지 않았을 경우 정상 처리하도록 수정

Resolves: N/A
Ref: N/A
Related to: N/A