### PR TITLE
Feat: "채팅 이미지 뷰 액티비티 추가"

### DIFF
--- a/android/ModuMessenger/app/src/main/AndroidManifest.xml
+++ b/android/ModuMessenger/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         <activity android:name=".Activity.ProfileImageActivity" />
         <activity android:name=".Activity.ProfileHistoryActivity" />
         <activity android:name=".Activity.SetAccountActivity" />
+        <activity android:name=".Activity.ChatImageActivity" />
 
         <activity
             android:name=".Activity.SplashActivity"

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatActivity.java
@@ -275,7 +275,7 @@ public class ChatActivity extends AppCompatActivity implements ChatSendOthersAct
 
         recentImageView.setOnClickListener(v -> {
             if(recentImageList.size() != 0) {
-                Intent intent = new Intent(v.getContext(), ProfileImageActivity.class);
+                Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
                 intent.putStringArrayListExtra("imageFileList", recentImageList);
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
@@ -283,6 +283,12 @@ public class ChatActivity extends AppCompatActivity implements ChatSendOthersAct
             } else {
                 Toast.makeText(this.getApplicationContext(),"채팅방에 전송된 사진이 없습니다.", Toast.LENGTH_SHORT).show();
             }
+        });
+
+        ConstraintLayout chatRoomMemberView = navigationView.findViewById(R.id.chatRoomMemberConstraintLayout);
+
+        chatRoomMemberView.setOnClickListener(v -> {
+            // need to implementation
         });
 
         Button ExitButton = navigationView.findViewById(R.id.nav_exit_button);
@@ -696,7 +702,7 @@ public class ChatActivity extends AppCompatActivity implements ChatSendOthersAct
                 recentChatImageGridAdapter.setGridItems(imageChatList);
 
                 recent_chat_images.setOnItemClickListener((parent, v, position, id) -> {
-                    Intent intent = new Intent(v.getContext(), ProfileImageActivity.class);
+                    Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
                     ArrayList<String> imageFileList = imageChatList.stream().skip(position).map(ChatDto::getMessage).collect(Collectors.toCollection(ArrayList::new));
                     intent.putStringArrayListExtra("imageFileList", imageFileList);
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatImageActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatImageActivity.java
@@ -1,0 +1,36 @@
+package com.example.modumessenger.Activity;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.modumessenger.R;
+
+public class ChatImageActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chat_image);
+
+        bindingView();
+        setData();
+        getData();
+        setEvents();
+    }
+
+    private void bindingView() {
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.hide();
+    }
+
+    private void setData() {
+    }
+
+    private void getData() {
+    }
+
+    private void setEvents() {
+    }
+}

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ProfileHistoryActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ProfileHistoryActivity.java
@@ -1,6 +1,5 @@
 package com.example.modumessenger.Activity;
 
-import static androidx.appcompat.widget.PopupMenu.*;
 import static com.example.modumessenger.Global.DataStoreHelper.getDataStoreMember;
 
 import android.os.Bundle;
@@ -11,6 +10,7 @@ import android.widget.PopupMenu;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -53,6 +53,9 @@ public class ProfileHistoryActivity extends AppCompatActivity {
     }
 
     private void bindingView() {
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setDisplayHomeAsUpEnabled(true);
+
         recyclerView = findViewById(R.id.profile_history_recycler_view);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
@@ -75,6 +78,18 @@ public class ProfileHistoryActivity extends AppCompatActivity {
 
     private void setEvents() {
 
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()){
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                break;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     public void getMemberInfoById(Long id) {

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ProfileImageActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ProfileImageActivity.java
@@ -2,8 +2,10 @@ package com.example.modumessenger.Activity;
 
 import static com.example.modumessenger.Global.DataStoreHelper.getDataStoreMember;
 
+import android.Manifest;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -58,7 +60,7 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-public class ProfileImageActivity  extends AppCompatActivity {
+public class ProfileImageActivity extends AppCompatActivity {
 
     ProfileType type;
     Long memberId, profileId;
@@ -176,6 +178,20 @@ public class ProfileImageActivity  extends AppCompatActivity {
     }
 
     public void saveFile(@NonNull final File file, @NonNull final String mimeType, @NonNull final String displayName) throws IOException {
+        // check permission
+        if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                Toast.makeText(this, "사진 다운로드를 취소 합니다.", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            requestPermissions(new String[]{
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+            }, 1000);
+
+            return;
+        }
+
         ContentValues values = new ContentValues();
         values.put(MediaStore.MediaColumns.DISPLAY_NAME, displayName);
         values.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
@@ -202,7 +218,7 @@ public class ProfileImageActivity  extends AppCompatActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) values.put(MediaStore.Images.Media.IS_PENDING, 0);
 
             contentResolver.update(item, values, null, null);
-            Toast.makeText(this, "사진이 저장되었습니다.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "사진이 저장 되었습니다.", Toast.LENGTH_SHORT).show();
         } catch (IOException e) {
             Toast.makeText(this, "사진을 저장할 수 없습니다.", Toast.LENGTH_SHORT).show();
             if (item != null) {

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatHistoryAdapter.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Adapter/ChatHistoryAdapter.java
@@ -17,8 +17,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.modumessenger.Activity.ChatImageActivity;
 import com.example.modumessenger.Activity.ProfileActivity;
-import com.example.modumessenger.Activity.ProfileImageActivity;
 import com.example.modumessenger.R;
 import com.example.modumessenger.entity.Member;
 import com.example.modumessenger.RoomDatabase.Database.ChatDatabase;
@@ -431,7 +431,7 @@ public class ChatHistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
         public void setChatImageClickEvent(ChatBubble chat) {
             this.chatImage.setOnClickListener(v -> {
-                Intent intent = new Intent(v.getContext(), ProfileImageActivity.class);
+                Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
 
                 ArrayList<String> imageFileList = new ArrayList<>();
                 imageFileList.add(chat.getChatMsg());
@@ -472,7 +472,7 @@ public class ChatHistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
         public void setChatImageClickEvent(ChatBubble chat) {
             this.chatImage.setOnClickListener(v -> {
-                Intent intent = new Intent(v.getContext(), ProfileImageActivity.class);
+                Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
 
                 ArrayList<String> imageFileList = new ArrayList<>();
                 imageFileList.add(chat.getChatMsg());
@@ -531,7 +531,7 @@ public class ChatHistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
         public void setChatImageClickEvent(ChatBubble chat) {
             this.chatImage.setOnClickListener(v -> {
-                Intent intent = new Intent(v.getContext(), ProfileImageActivity.class);
+                Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
 
                 ArrayList<String> imageFileList = new ArrayList<>();
                 imageFileList.add(chat.getChatMsg());

--- a/android/ModuMessenger/app/src/main/res/layout/activity_chat_image.xml
+++ b/android/ModuMessenger/app/src/main/res/layout/activity_chat_image.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Feat: "채팅 이미지 뷰 액티비티 추가"

채팅 이미지 뷰 액티비티 추가
- 프로필 이미지와 채팅 이미지 뷰 액티비티 분리
- 채팅방 멤버 보기 버튼 활성화
- 프로필 히스토리 뒤로 가기 버튼 추가 이미지 다운로드 버튼 클릭시 권한 승인 요청 추가
- 이미지 다운로드시 권한 요청후 다운로드 하도록 수정

Resolves: N/A
Ref: N/A
Related to: N/A