### PR TITLE
Feat: "이미지 채팅 전송후 이미지 클릭시 종료되는 문제 수정"

### DIFF
--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatImageActivity.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Activity/ChatImageActivity.java
@@ -14,6 +14,7 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.example.modumessenger.Adapter.ChatImageSliderAdapter;
 import com.example.modumessenger.R;
+import com.example.modumessenger.Retrofit.APIHelper;
 import com.example.modumessenger.Retrofit.RetrofitChatAPI;
 import com.example.modumessenger.Retrofit.RetrofitClient;
 import com.example.modumessenger.dto.ChatDto;
@@ -102,9 +103,9 @@ public class ChatImageActivity extends AppCompatActivity {
 
     // Retrofit function
     public void getChatList(List<String> chatImageList) {
-        Call<List<ChatDto>> chatDtoCall = retrofitChatAPI.RequestChatList(chatImageList);
+        Call<List<ChatDto>> call = retrofitChatAPI.RequestChatList(chatImageList);
 
-        chatDtoCall.enqueue(new Callback<List<ChatDto>>() {
+        APIHelper.enqueueWithRetry(call, 5, new Callback<List<ChatDto>>() {
             @Override
             public void onResponse(@NonNull Call<List<ChatDto>> call, @NonNull Response<List<ChatDto>> response) {
                 if (response.isSuccessful()) {

--- a/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Grid/RecentChatImageGridAdapter.java
+++ b/android/ModuMessenger/app/src/main/java/com/example/modumessenger/Grid/RecentChatImageGridAdapter.java
@@ -2,6 +2,7 @@ package com.example.modumessenger.Grid;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,18 +12,21 @@ import android.widget.ImageView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.LazyHeaders;
+import com.example.modumessenger.Activity.ChatImageActivity;
 import com.example.modumessenger.Global.DataStoreHelper;
 import com.example.modumessenger.R;
 import com.example.modumessenger.Retrofit.RetrofitClient;
 import com.example.modumessenger.dto.ChatDto;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class RecentChatImageGridAdapter extends BaseAdapter {
     private final Context context;
     private final List<RecentChatImageGridItem> recentChatImageGridItems;
+    private ArrayList<String> recentImageList;
 
     public RecentChatImageGridAdapter(Context context) {
         this.context = context;
@@ -54,6 +58,14 @@ public class RecentChatImageGridAdapter extends BaseAdapter {
 
         ImageView itemImageView = convertView.findViewById(R.id.recent_chat_image_view);
 
+        itemImageView.setOnClickListener(v -> {
+            Intent intent = new Intent(v.getContext(), ChatImageActivity.class);
+            intent.putStringArrayListExtra("chatImageList", new ArrayList<>(Collections.singletonList(recentImageList.get(position))));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            v.getContext().startActivity(intent);
+        });
+
         String accessToken = DataStoreHelper.getDataStoreStr("access-token");
         String url = RetrofitClient.getBaseUrl() + "storage-service/view/"+ recentChatImageGridItem.getImageUrl();
 
@@ -70,6 +82,10 @@ public class RecentChatImageGridAdapter extends BaseAdapter {
                 .into(itemImageView);
 
         return convertView;
+    }
+
+    public void setRecentImageList(ArrayList<String> recentImageList) {
+        this.recentImageList = recentImageList;
     }
 
     public void setGridItems(List<ChatDto> chatDtoList) {

--- a/android/ModuMessenger/app/src/main/res/layout/activity_chat.xml
+++ b/android/ModuMessenger/app/src/main/res/layout/activity_chat.xml
@@ -242,9 +242,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="1.0"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/view2">
-
-                </GridView>
+                    app:layout_constraintTop_toBottomOf="@+id/view2" />
 
                 <View
                     android:id="@+id/view3"

--- a/android/ModuMessenger/app/src/main/res/layout/recent_chat_image_grid_item.xml
+++ b/android/ModuMessenger/app/src/main/res/layout/recent_chat_image_grid_item.xml
@@ -14,6 +14,7 @@
         android:minWidth="90dp"
         android:minHeight="90dp"
         android:maxHeight="90dp"
+        android:scaleType="centerCrop"
         android:adjustViewBounds="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Feat: "이미지 채팅 전송후 이미지 클릭시 종료되는 문제 수정"

이지 채팅 전송후 이미지 클릭시 앱 종료되는 문제 수정
- 웹 소켓 응답 데이터 로직 변경 (객체로 변환 하도록 수정)
채팅방 최근 전송 이미지 클릭시 뷰어 이동 이동하도록 추가
- 채팅방 최근 전송 이미지 리스트 클릭스 뷰어 이동 이벤트 추가
최근 전송 이미지 이미지 맞춤 설정 추가
- 이미지 가운데 채우도록 수정

Resolves: N/A
Ref: N/A
Related to: N/A