### PR TITLE
Feat: "서비스 마다 사용 데이터 베이스 분리"

### DIFF
--- a/backend/auth-service/build.gradle
+++ b/backend/auth-service/build.gradle
@@ -19,7 +19,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -29,10 +29,16 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+	// com.sun.xml.bind
+	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
+	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+	// javax.xml.bind
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/auth-service/src/main/java/com/example/authservice/AuthServiceApplication.java
+++ b/backend/auth-service/src/main/java/com/example/authservice/AuthServiceApplication.java
@@ -4,8 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @EnableFeignClients
 @SpringBootApplication

--- a/backend/auth-service/src/main/java/com/example/authservice/service/AccessTokenService.java
+++ b/backend/auth-service/src/main/java/com/example/authservice/service/AccessTokenService.java
@@ -6,8 +6,7 @@ import com.example.authservice.exception.CustomException;
 import com.example.authservice.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/auth-service/src/main/java/com/example/authservice/service/RefreshTokenService.java
+++ b/backend/auth-service/src/main/java/com/example/authservice/service/RefreshTokenService.java
@@ -8,8 +8,8 @@ import com.example.authservice.exception.CustomException;
 import com.example.authservice.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 @Service

--- a/backend/auth-service/src/main/resources/application.yml
+++ b/backend/auth-service/src/main/resources/application.yml
@@ -5,12 +5,6 @@ spring:
   application:
     name: auth-service
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/modu-chat?serverTimezone=Asia/Seoul
-    username: root
-    password: root1234
-
   redis:
     host: localhost
     port: 6379
@@ -20,16 +14,6 @@ spring:
     port: 5672
     username: guest
     password: guest
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        show-sql: true
-        format_sql: true
-        default_batch_fetch_size: 1000
-    open-in-view: false
 
   sleuth:
     sampler:

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -54,7 +54,7 @@ function print_log()
 # find service in directories
 function find_service()
 {
-    local excludes="README.md docker-compose.yml build.sh"
+    local excludes="ModuMessenger README.md docker-compose.yml build.sh"
     local list=`ls`
     local result=""
 

--- a/backend/chat-service/Dockerfile
+++ b/backend/chat-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-jdk-alpine
+FROM openjdk:17-jdk-alpine
 
 ARG JAR_FILE=build/libs/chat-service-0.0.1-SNAPSHOT.jar
 

--- a/backend/chat-service/src/main/resources/application.yml
+++ b/backend/chat-service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/modu-chat?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3307/modu-chat?serverTimezone=Asia/Seoul
     username: root
     password: root1234
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3.8'
 
 services:
-  mysql:
+  mysql-member:
     image: mysql
-    container_name: mysql
+    container_name: mysql-member
     ports:
       - 3306:3306
     volumes:
-      - mysql-data:/var/lib/mysql
+      - mysql-member:/var/lib/mysql
     environment:
       MYSQL_DATABASE: modu-chat
       MYSQL_USER: user 
@@ -23,6 +23,72 @@ services:
       retries: 100
     restart: always
   
+  mysql-chat:
+    image: mysql
+    container_name: mysql-chat
+    ports:
+      - 3307:3306
+    volumes:
+      - mysql-chat:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: modu-chat
+      MYSQL_USER: user 
+      MYSQL_PASSWORD: userpwd
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: root1234
+    networks:
+      - modu-chat-network
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD']
+      interval: 10s
+      timeout: 2s
+      retries: 100
+    restart: always
+  
+  mysql-push:
+    image: mysql
+    container_name: mysql-push
+    ports:
+      - 3308:3306
+    volumes:
+      - mysql-push:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: modu-chat
+      MYSQL_USER: user 
+      MYSQL_PASSWORD: userpwd
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: root1234
+    networks:
+      - modu-chat-network
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD']
+      interval: 10s
+      timeout: 2s
+      retries: 100
+    restart: always
+  
+  mysql-profile:
+    image: mysql
+    container_name: mysql-profile
+    ports:
+      - 3309:3306
+    volumes:
+      - mysql-profile:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: modu-chat
+      MYSQL_USER: user 
+      MYSQL_PASSWORD: userpwd
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: root1234
+    networks:
+      - modu-chat-network
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD']
+      interval: 10s
+      timeout: 2s
+      retries: 100
+    restart: always
+
   redis:
     image: redis:alpine
     command: redis-server --port 6379
@@ -61,7 +127,7 @@ services:
     networks:
       - modu-chat-network
     volumes:
-      - /Users/imjunseob/data:/data
+      - /var/modu-chat/minio/data:/data
 
   zipkin:
     container_name: zipkin
@@ -107,14 +173,10 @@ services:
     ports:
       - 9900:9900
     environment:
-      - spring.datasource.url=jdbc:mysql://mysql:3306/modu-chat
-      - spring.datasource.username=root
-      - spring.datasource.password=root1234
       - eureka.client.serviceUrl.defaultZone=http://discovery-service:8761/eureka/
       - spring.zipkin.base-url=http://zipkin:9411
       - spring.redis.host=redis
     depends_on:
-      - mysql
       - discovery-service
       - zipkin
       - redis
@@ -130,14 +192,14 @@ services:
     ports:
       - 9090:9090
     environment:
-      - spring.datasource.url=jdbc:mysql://mysql:3306/modu-chat
+      - spring.datasource.url=jdbc:mysql://mysql-chat:3306/modu-chat
       - spring.datasource.username=root
       - spring.datasource.password=root1234
       - eureka.client.serviceUrl.defaultZone=http://discovery-service:8761/eureka/
       - spring.zipkin.base-url=http://zipkin:9411
       - spring.redis.host=redis
     depends_on:
-      - mysql
+      - mysql-chat
       - discovery-service
       - zipkin
       - redis
@@ -153,14 +215,14 @@ services:
     ports:
       - 8080:8080
     environment:
-      - spring.datasource.url=jdbc:mysql://mysql:3306/modu-chat
+      - spring.datasource.url=jdbc:mysql://mysql-member:3306/modu-chat
       - spring.datasource.username=root
       - spring.datasource.password=root1234
       - eureka.client.serviceUrl.defaultZone=http://discovery-service:8761/eureka/
       - spring.zipkin.base-url=http://zipkin:9411
       - spring.redis.host=redis
     depends_on:
-      - mysql
+      - mysql-member
       - discovery-service
       - zipkin
       - redis
@@ -176,14 +238,14 @@ services:
     ports:
       - 8880:8880
     environment:
-      - spring.datasource.url=jdbc:mysql://mysql:3306/modu-chat
+      - spring.datasource.url=jdbc:mysql://mysql-profile:3306/modu-chat
       - spring.datasource.username=root
       - spring.datasource.password=root1234
       - eureka.client.serviceUrl.defaultZone=http://discovery-service:8761/eureka/
       - spring.zipkin.base-url=http://zipkin:9411
       - spring.redis.host=redis
     depends_on:
-      - mysql
+      - mysql-profile
       - discovery-service
       - zipkin
     networks:
@@ -198,14 +260,14 @@ services:
     ports:
       - 9990:9990
     environment:
-      - spring.datasource.url=jdbc:mysql://mysql:3306/modu-chat
+      - spring.datasource.url=jdbc:mysql://mysql-push:3306/modu-chat
       - spring.datasource.username=root
       - spring.datasource.password=root1234
       - eureka.client.serviceUrl.defaultZone=http://discovery-service:8761/eureka/
       - spring.zipkin.base-url=http://zipkin:9411
       - spring.redis.host=redis
     depends_on:
-      - mysql
+      - mysql-push
       - discovery-service
       - zipkin
       - redis
@@ -229,7 +291,6 @@ services:
       - spring.redis.host=redis
       - minio.endpoint=http://minio:9000
     depends_on:
-      - mysql
       - minio
       - discovery-service
       - zipkin
@@ -238,7 +299,7 @@ services:
       - modu-chat-network
     restart: always
     volumes:
-      - /Users/imjunseob/data:/data
+      - /var/modu-chat/storage/data:/data
 
   ws-service:
     build:
@@ -256,7 +317,7 @@ services:
       - spring.redis.host=redis
       - spring.rabbitmq.host=rabbitmq
     depends_on:
-      - mysql
+      - mysql-chat
       - discovery-service
       - zipkin
       - redis
@@ -270,3 +331,7 @@ networks:
 
 volumes:
   mysql-data:
+  mysql-member:
+  mysql-chat:
+  mysql-push:
+  mysql-profile:

--- a/backend/member-service/build.gradle
+++ b/backend/member-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
@@ -40,6 +41,7 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/backend/member-service/src/main/java/com/example/memberservice/member/entity/friend/Friend.java
+++ b/backend/member-service/src/main/java/com/example/memberservice/member/entity/friend/Friend.java
@@ -10,7 +10,7 @@ import java.util.List;
 public abstract class Friend {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "friend_id")
     private Long id;
 

--- a/backend/member-service/src/main/resources/application.yml
+++ b/backend/member-service/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
 
   datasource:
     url: jdbc:mysql://localhost:3306/modu-chat?serverTimezone=Asia/Seoul
-    #    url: jdbc:mysql://database:3306/modu-chat
     username: root
     password: root1234
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -76,6 +75,14 @@ resilience4j:
 logging:
   level:
     org.hibernate.SQL: debug
+
+management:
+  server:
+    port: 8082
+  endpoints:
+    web:
+      exposure:
+        include: "*"
 
 eureka:
   instance:

--- a/backend/profile-service/src/main/java/com/example/profileservice/profile/entity/Profile.java
+++ b/backend/profile-service/src/main/java/com/example/profileservice/profile/entity/Profile.java
@@ -5,9 +5,7 @@ import com.example.profileservice.profile.dto.CreateProfileDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -15,7 +13,8 @@ import javax.persistence.Id;
 public class Profile extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @Column(name = "profile_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Long memberId;

--- a/backend/profile-service/src/main/resources/application.yaml
+++ b/backend/profile-service/src/main/resources/application.yaml
@@ -14,8 +14,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:mysql://localhost:3306/modu-chat?serverTimezone=Asia/Seoul
-    #    url: jdbc:mysql://database:3306/modu-chat
+    url: jdbc:mysql://localhost:3309/modu-chat?serverTimezone=Asia/Seoul
     username: root
     password: root1234
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/backend/push-service/src/main/java/com/example/pushservice/fcm/controller/FcmController.java
+++ b/backend/push-service/src/main/java/com/example/pushservice/fcm/controller/FcmController.java
@@ -35,7 +35,7 @@ public class FcmController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/chat/{userId}/token")
+    @PutMapping("/push/{userId}/token")
     public ResponseEntity<String> registerFcmToken(@PathVariable("userId") String userId, @RequestBody String token) {
         FcmToken fcmToken = new FcmToken(userId, token);
         FcmToken saveToken = fcmService.saveFcmToken(fcmToken);

--- a/backend/push-service/src/main/resources/application.yml
+++ b/backend/push-service/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/modu-chat?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3308/modu-chat?serverTimezone=Asia/Seoul
     username: root
     password: root1234
 


### PR DESCRIPTION
Feat: "서비스 마다 사용 데이터 베이스 분리"

서비스 데이터 베이스 분리
- member, chat, push, profile 데이터 베이스 분리
- 서비스마다 application.yml 파일 수정 도커 컴포즈 파일 수정
- 데이터 베이스 추가로 3개 추가
- 볼륨 경로 수정, 각자 서비스 이름 경로의 볼륨 사용하도록 수정 push 서비스 토큰 발급 api path 수정
- push 서비스의 api 이므로 불필요 경로 삭제 및 수정 유니크 아이디 identity 사용하도록 일괄 수정

Resolves: N/A
Ref: N/A
Related to: N/A